### PR TITLE
 feat(RDGRS-1288): updated go code to implement gracefull shutdown logic to listen on SIGTERM Signals 

### DIFF
--- a/share/cos/common.go
+++ b/share/cos/common.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/signal"
 	"time"
+	"syscall"
 )
 
 //InterruptContext returns a context which is
@@ -13,7 +14,7 @@ func InterruptContext() context.Context {
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
 		sig := make(chan os.Signal, 1)
-		signal.Notify(sig, os.Interrupt) //windows compatible?
+		signal.Notify(sig, os.Interrupt, syscall.SIGTERM) //windows compatible?
 		<-sig
 		signal.Stop(sig)
 		cancel()


### PR DESCRIPTION
Jira Issue
[RDGRS-1288](https://outsystemsrd.atlassian.net/browse/RDGRS-1288)

Context / Goal
The Chisel server container runs within AWS ECS Fargate, and during ECS task rotations, containers receive a SIGTERM signal before termination. Previously, the Chisel server did not handle SIGTERM, leading to abrupt shutdowns and potential downtime.

This PR enhances the container behavior by implementing graceful termination upon SIGTERM, ensuring cleanup occurs before exit. While this has not been tested directly in ECS Fargate, validation was performed in a local Kubernetes (k3d) cluster, which exhibits similar container lifecycle behavior, enabling faster iteration and reliable results.

Changes in this PR:
Added signal handling logic to the Chisel server to intercept SIGTERM and shut down cleanly.
Verified behavior in a local k3d Kubernetes cluster simulating ECS termination signals.
Included explanatory comments noting that SIGKILL (kill -9) cannot be handled, as it’s enforced by the OS.

Acceptance Criteria:
Chisel server intercepts SIGTERM and shuts down gracefully.
Behavior tested and confirmed in a local Kubernetes (k3d) environment.
Improves ECS task rotation by reducing downtime and enabling orderly shutdowns.
No handling logic for SIGKILL (expected OS behavior).

Server/Client Screenshot :

[RDGRS-1288]: https://outsystemsrd.atlassian.net/browse/RDGRS-1288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ